### PR TITLE
[Feature] 매물 CRUD API 구현

### DIFF
--- a/src/main/java/blockchain/project/khu/apiserver/common/apiPayload/failure/GlobalExceptionHandler.java
+++ b/src/main/java/blockchain/project/khu/apiserver/common/apiPayload/failure/GlobalExceptionHandler.java
@@ -1,8 +1,10 @@
 package blockchain.project.khu.apiserver.common.apiPayload.failure;
 
 import blockchain.project.khu.apiserver.common.apiPayload.failure.customException.JWTException;
+import blockchain.project.khu.apiserver.common.apiPayload.failure.customException.PropertyException;
 import blockchain.project.khu.apiserver.common.apiPayload.failure.customException.UserException;
 import blockchain.project.khu.apiserver.common.apiPayload.failure.customExceptionStatus.JWTExceptionStatus;
+import blockchain.project.khu.apiserver.common.apiPayload.failure.customExceptionStatus.PropertyExceptionStatus;
 import blockchain.project.khu.apiserver.common.apiPayload.failure.customExceptionStatus.UserExceptionStatus;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -109,6 +111,35 @@ public class GlobalExceptionHandler {
                 .body(
                         new ExceptionApiResponse(
                                 false, UserExceptionStatus.USERNAME_NOT_EXIST.getCode(), UserExceptionStatus.USERNAME_NOT_EXIST.getMessage()
+                        )
+                );
+    }
+
+    // [PROPERTY]
+    @ExceptionHandler(PropertyException.PropertyNotFound.class)
+    public ResponseEntity<ExceptionApiResponse> handleException(PropertyException.PropertyNotFound e){
+        log.error("[GlobalExceptionHandler PropertyException.PROPERTY_NOT_FOUND occurred");
+        return ResponseEntity
+                .status(
+                        PropertyExceptionStatus.PROPERTY_NOT_FOUND.getHttpStatus()
+                )
+                .body(
+                        new ExceptionApiResponse(
+                                false, PropertyExceptionStatus.PROPERTY_NOT_FOUND.getCode(), PropertyExceptionStatus.PROPERTY_NOT_FOUND.getMessage()
+                        )
+                );
+    }
+
+    @ExceptionHandler(PropertyException.PropertyInvalidInputException.class)
+    public ResponseEntity<ExceptionApiResponse> handleException(PropertyException.PropertyInvalidInputException e){
+        log.error("[GlobalExceptionHandler PropertyException.PropertyInvalidInputException occurred");
+        return ResponseEntity
+                .status(
+                        PropertyExceptionStatus.PROPERTY_INVALID_INPUT.getHttpStatus()
+                )
+                .body(
+                        new ExceptionApiResponse(
+                                false, PropertyExceptionStatus.PROPERTY_INVALID_INPUT.getCode(), PropertyExceptionStatus.PROPERTY_INVALID_INPUT.getMessage()
                         )
                 );
     }

--- a/src/main/java/blockchain/project/khu/apiserver/common/apiPayload/failure/customException/PropertyException.java
+++ b/src/main/java/blockchain/project/khu/apiserver/common/apiPayload/failure/customException/PropertyException.java
@@ -1,0 +1,10 @@
+package blockchain.project.khu.apiserver.common.apiPayload.failure.customException;
+
+import blockchain.project.khu.apiserver.common.apiPayload.BaseApiResponse;
+
+public class PropertyException{
+
+    public static class PropertyNotFound extends RuntimeException{}
+    public static class PropertyInvalidInputException extends RuntimeException{}
+    public static class PropertyDuplicateException extends RuntimeException{}
+}

--- a/src/main/java/blockchain/project/khu/apiserver/common/apiPayload/failure/customExceptionStatus/PropertyExceptionStatus.java
+++ b/src/main/java/blockchain/project/khu/apiserver/common/apiPayload/failure/customExceptionStatus/PropertyExceptionStatus.java
@@ -1,0 +1,21 @@
+package blockchain.project.khu.apiserver.common.apiPayload.failure.customExceptionStatus;
+
+import blockchain.project.khu.apiserver.common.apiPayload.BaseApiResponse;
+import blockchain.project.khu.apiserver.common.apiPayload.failure.ExceptionApiResponse;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum PropertyExceptionStatus{
+
+    PROPERTY_NOT_FOUND      (HttpStatus.NOT_FOUND,    "PROPERTY_NOT_FOUND",      "존재하지 않는 매물입니다."),
+    PROPERTY_INVALID_INPUT  (HttpStatus.BAD_REQUEST,  "PROPERTY_INVALID_INPUT",  "잘못된 매물 요청입니다."),
+    PROPERTY_DUPLICATE      (HttpStatus.FORBIDDEN,    "PROPERTY_DUPLICATE",      "이미 매물이 존재합니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/blockchain/project/khu/apiserver/common/apiPayload/failure/customExceptionStatus/UserExceptionStatus.java
+++ b/src/main/java/blockchain/project/khu/apiserver/common/apiPayload/failure/customExceptionStatus/UserExceptionStatus.java
@@ -11,7 +11,8 @@ public enum UserExceptionStatus {
     PASSWORD_NOT_VALID(HttpStatus.BAD_REQUEST, "40001", "비밀번호가 일치하지 않습니다."),
     TOKEN_NOT_VALID(HttpStatus.BAD_REQUEST, "40002", "토큰이 유효하지 않습니다."),
     USERNAME_NOT_EXIST(HttpStatus.BAD_REQUEST, "40003", "존재하지 않는 사용자 아이디입니다."),
-
+    AUTHENTICATION_NOT_FOUND(HttpStatus.UNAUTHORIZED, "JWT407", "인증 정보를 찾을 수 없습니다."),
+    UNKNOWN_PRINCIPAL_TYPE(HttpStatus.UNAUTHORIZED, "JWT408", "알 수 없는 사용자 타입입니다.");
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/blockchain/project/khu/apiserver/common/apiPayload/success/SuccessApiResponse.java
+++ b/src/main/java/blockchain/project/khu/apiserver/common/apiPayload/success/SuccessApiResponse.java
@@ -1,9 +1,13 @@
 package blockchain.project.khu.apiserver.common.apiPayload.success;
 
 import blockchain.project.khu.apiserver.common.apiPayload.BaseApiResponse;
+import blockchain.project.khu.apiserver.domain.property.dto.response.PropertyResponseDto;
 import blockchain.project.khu.apiserver.domain.user.dto.response.LoginResponse;
+import com.sun.net.httpserver.Authenticator;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
+
+import java.util.List;
 
 @Getter
 public class SuccessApiResponse <T> extends BaseApiResponse {
@@ -26,5 +30,26 @@ public class SuccessApiResponse <T> extends BaseApiResponse {
     public static SuccessApiResponse<Void> ReissueToken(){
         return new SuccessApiResponse<>(true, HttpStatus.OK.toString()
                 , "토큰 재발급 성공", null);
+    }
+
+    // [PROPERTY]
+    public static SuccessApiResponse<PropertyResponseDto> createProperty(PropertyResponseDto responseDto) {
+        return new SuccessApiResponse<>(true, HttpStatus.CREATED.toString(), "매물 등록 성공", responseDto);
+    }
+
+    public static SuccessApiResponse<PropertyResponseDto> getProperty(PropertyResponseDto responseDto) {
+        return new SuccessApiResponse<>(true, HttpStatus.FOUND.toString(), "매물 조회 성공", responseDto);
+    }
+
+    public static SuccessApiResponse<List<PropertyResponseDto>> getProperties(List<PropertyResponseDto> responseDtoList) {
+        return new SuccessApiResponse<>(true, HttpStatus.FOUND.toString(), "매물 조회 성공", responseDtoList);
+    }
+
+    public static SuccessApiResponse<PropertyResponseDto> updateProperty(PropertyResponseDto responseDto) {
+        return new SuccessApiResponse<>(true, HttpStatus.OK.toString(), "매물 수정 성공", responseDto);
+    }
+
+    public static SuccessApiResponse<Void> deleteProperty() {
+        return new SuccessApiResponse<>(true, HttpStatus.OK.toString(), "매물 삭제 성공", null);
     }
 }

--- a/src/main/java/blockchain/project/khu/apiserver/common/util/SecurityUtil.java
+++ b/src/main/java/blockchain/project/khu/apiserver/common/util/SecurityUtil.java
@@ -1,0 +1,39 @@
+package blockchain.project.khu.apiserver.common.util;
+
+import blockchain.project.khu.apiserver.common.apiPayload.failure.customExceptionStatus.JWTExceptionStatus;
+import blockchain.project.khu.apiserver.common.apiPayload.failure.customExceptionStatus.UserExceptionStatus;
+import blockchain.project.khu.apiserver.domain.user.dto.userDetails.RoleUserDetails;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+@Slf4j
+public class SecurityUtil {
+
+    public static Long getCurrentMemberId() {
+
+        // Spring Security가 현재 요청을 처리하는 스레드의 인증 정보를 담고 있는 컨텍스트
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        log.info("Authentication: {}", authentication);
+
+        if (authentication == null || authentication.getPrincipal() == null) {
+            throw new SecurityException(UserExceptionStatus.USERNAME_NOT_EXIST.getMessage());
+        }
+
+        // principal은 로그인한 사용자의 정보 객체
+        //JWT 기반 인증에서는 일반적으로 CustomUserDetails 혹은 String(ID 값) 형태로 존재
+        Object principal = authentication.getPrincipal();
+
+        if (principal instanceof RoleUserDetails) {
+            return ((RoleUserDetails) principal).getUserId();
+        } else if (principal instanceof String) {
+            try {
+                return Long.valueOf((String) principal);
+            } catch (NumberFormatException e) {
+                throw new SecurityException(UserExceptionStatus.AUTHENTICATION_NOT_FOUND.getMessage());
+            }
+        } else {
+            throw new SecurityException(UserExceptionStatus.UNKNOWN_PRINCIPAL_TYPE.getMessage());
+        }
+    }
+}

--- a/src/main/java/blockchain/project/khu/apiserver/domain/property/controller/PropertyController.java
+++ b/src/main/java/blockchain/project/khu/apiserver/domain/property/controller/PropertyController.java
@@ -1,0 +1,57 @@
+package blockchain.project.khu.apiserver.domain.property.controller;
+
+import blockchain.project.khu.apiserver.common.apiPayload.success.SuccessApiResponse;
+import blockchain.project.khu.apiserver.domain.property.dto.request.PropertyRequestDto;
+import blockchain.project.khu.apiserver.domain.property.dto.response.PropertyResponseDto;
+import blockchain.project.khu.apiserver.domain.property.service.PropertyService;
+import com.sun.net.httpserver.Authenticator;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/property")
+@RequiredArgsConstructor
+public class PropertyController {
+
+    private final PropertyService propertyService;
+
+    // 등록
+    @PostMapping()
+    public SuccessApiResponse<PropertyResponseDto> createProperty(@RequestBody PropertyRequestDto dto) {
+        PropertyResponseDto property = propertyService.createProperty(dto);
+        return SuccessApiResponse.createProperty(property);
+    }
+
+    // 단건 조회
+    @GetMapping("/{propertyId}")
+    public SuccessApiResponse<PropertyResponseDto> getProperty(@PathVariable Long propertyId){
+        PropertyResponseDto property = propertyService.getProperty(propertyId);
+        return SuccessApiResponse.getProperty(property);
+    }
+
+    // 목록 조회
+    @GetMapping()
+    public SuccessApiResponse<List<PropertyResponseDto>> getProperties() {
+        List<PropertyResponseDto> properties = propertyService.getProperties();
+        return SuccessApiResponse.getProperties(properties);
+    }
+
+    // 수정
+    @PutMapping("/{propertyId}")
+    public SuccessApiResponse<PropertyResponseDto> updateProperty(
+            @PathVariable Long propertyId,
+            @RequestBody PropertyRequestDto dto)
+    {
+        PropertyResponseDto responseDto = propertyService.updateProperty(propertyId, dto);
+        return SuccessApiResponse.updateProperty(responseDto);
+    }
+
+    // 삭제
+    @DeleteMapping("/{propertyId}")
+    public SuccessApiResponse<Void> deleteProperty(@PathVariable Long propertyId){
+        propertyService.deleteProperty(propertyId);
+        return SuccessApiResponse.deleteProperty();
+    }
+}

--- a/src/main/java/blockchain/project/khu/apiserver/domain/property/dto/request/PropertyRequestDto.java
+++ b/src/main/java/blockchain/project/khu/apiserver/domain/property/dto/request/PropertyRequestDto.java
@@ -1,0 +1,38 @@
+package blockchain.project.khu.apiserver.domain.property.dto.request;
+
+
+import blockchain.project.khu.apiserver.domain.property.entity.Property;
+import blockchain.project.khu.apiserver.domain.property.entity.PropertyStatus;
+import blockchain.project.khu.apiserver.domain.user.entity.User;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.parameters.P;
+
+@Data
+@Builder
+public class PropertyRequestDto {
+
+    @NotBlank(message = "건물 이름은 비어있을 수 없습니다.")
+    private String name;
+
+    @NotBlank
+    private String address;
+
+    private String description;
+
+    @NotBlank(message = "금액은 비어있을 수 없습니다.")
+    private String price;
+
+    public Property toEntity(User user) {
+        return Property.builder()
+                .name(name)
+                .address(address)
+                .description(description)
+                .price(price)
+                .user(user)
+                .status(PropertyStatus.AVAILABLE)
+                .build();
+    }
+}

--- a/src/main/java/blockchain/project/khu/apiserver/domain/property/dto/response/PropertyResponseDto.java
+++ b/src/main/java/blockchain/project/khu/apiserver/domain/property/dto/response/PropertyResponseDto.java
@@ -1,0 +1,32 @@
+package blockchain.project.khu.apiserver.domain.property.dto.response;
+
+import blockchain.project.khu.apiserver.domain.property.entity.Property;
+import blockchain.project.khu.apiserver.domain.property.entity.PropertyStatus;
+import blockchain.project.khu.apiserver.domain.user.entity.User;
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class PropertyResponseDto {
+    private Long id;
+    private Long userId;
+    private String name;
+    private String address;
+    private String description;
+    private PropertyStatus status;
+    private String price;
+
+    public static PropertyResponseDto fromEntity(Property property){
+        return PropertyResponseDto.builder()
+                .id(property.getId())
+                .userId(property.getUser().getId())
+                .name(property.getName())
+                .address(property.getAddress())
+                .description(property.getDescription())
+                .status(property.getStatus())
+                .price(property.getPrice())
+                .build();
+    }
+}

--- a/src/main/java/blockchain/project/khu/apiserver/domain/property/entity/Property.java
+++ b/src/main/java/blockchain/project/khu/apiserver/domain/property/entity/Property.java
@@ -1,0 +1,47 @@
+package blockchain.project.khu.apiserver.domain.property.entity;
+
+import blockchain.project.khu.apiserver.domain.property.dto.request.PropertyRequestDto;
+import blockchain.project.khu.apiserver.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "property")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Property {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "property_id")
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Column(name = "property_name", nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private String address;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private PropertyStatus status;
+
+    @Column(nullable = false)
+    private String price;
+
+    public void update(PropertyRequestDto requestDto){
+        this.name = requestDto.getName();
+        this.address = requestDto.getAddress();
+        this.description = requestDto.getDescription();
+        this.price = requestDto.getPrice();
+    }
+}

--- a/src/main/java/blockchain/project/khu/apiserver/domain/property/entity/PropertyStatus.java
+++ b/src/main/java/blockchain/project/khu/apiserver/domain/property/entity/PropertyStatus.java
@@ -1,0 +1,6 @@
+package blockchain.project.khu.apiserver.domain.property.entity;
+
+public enum PropertyStatus {
+    AVAILABLE,
+    SOLD
+}

--- a/src/main/java/blockchain/project/khu/apiserver/domain/property/repository/PropertyRepository.java
+++ b/src/main/java/blockchain/project/khu/apiserver/domain/property/repository/PropertyRepository.java
@@ -1,0 +1,9 @@
+package blockchain.project.khu.apiserver.domain.property.repository;
+
+import blockchain.project.khu.apiserver.domain.property.entity.Property;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PropertyRepository extends JpaRepository<Property, Long> {
+}

--- a/src/main/java/blockchain/project/khu/apiserver/domain/property/service/PropertyService.java
+++ b/src/main/java/blockchain/project/khu/apiserver/domain/property/service/PropertyService.java
@@ -1,0 +1,71 @@
+package blockchain.project.khu.apiserver.domain.property.service;
+
+import blockchain.project.khu.apiserver.common.apiPayload.failure.customException.PropertyException;
+import blockchain.project.khu.apiserver.common.apiPayload.failure.customException.UserException;
+import blockchain.project.khu.apiserver.common.util.SecurityUtil;
+import blockchain.project.khu.apiserver.domain.property.dto.request.PropertyRequestDto;
+import blockchain.project.khu.apiserver.domain.property.dto.response.PropertyResponseDto;
+import blockchain.project.khu.apiserver.domain.property.entity.Property;
+import blockchain.project.khu.apiserver.domain.property.repository.PropertyRepository;
+import blockchain.project.khu.apiserver.domain.user.entity.User;
+import blockchain.project.khu.apiserver.domain.user.jwt.JWTUtil;
+import blockchain.project.khu.apiserver.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.security.Security;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class PropertyService {
+
+    private final PropertyRepository propertyRepository;
+    private final UserRepository userRepository;
+    // 등록
+    public PropertyResponseDto createProperty(PropertyRequestDto request){
+        Long userId = SecurityUtil.getCurrentMemberId();
+        User user = userRepository.findById(userId).orElseThrow(UserException.UsernameNotExistException::new);
+
+        Property property = request.toEntity(user);
+
+        propertyRepository.save(property);
+
+        return PropertyResponseDto.fromEntity(property);
+    }
+
+    // 단건 조회
+    public PropertyResponseDto getProperty(Long propertyId) {
+        Property property = propertyRepository.findById(propertyId)
+                .orElseThrow(PropertyException.PropertyNotFound::new);
+        return PropertyResponseDto.fromEntity(property);
+    }
+
+    // 목록 조회
+    public List<PropertyResponseDto> getProperties() {
+        List<Property> propertyList = propertyRepository.findAll();
+        return propertyList.stream()
+                .map(PropertyResponseDto::fromEntity)
+                .collect(Collectors.toList());
+    }
+
+    // 삭제
+    public void deleteProperty(Long propertyId){
+        Property property = propertyRepository.findById(propertyId)
+                .orElseThrow(PropertyException.PropertyNotFound::new);
+        propertyRepository.delete(property);
+
+    }
+
+    // 수정
+    public PropertyResponseDto updateProperty(Long propertyId, PropertyRequestDto requestDto){
+        Property property = propertyRepository.findById(propertyId).orElseThrow(PropertyException.PropertyNotFound::new);
+        property.update(requestDto);
+        return PropertyResponseDto.fromEntity(property);
+    }
+}

--- a/src/main/java/blockchain/project/khu/apiserver/domain/user/dto/userDetails/RoleUserDetails.java
+++ b/src/main/java/blockchain/project/khu/apiserver/domain/user/dto/userDetails/RoleUserDetails.java
@@ -31,6 +31,8 @@ public class RoleUserDetails implements UserDetails {
         return userAccessDto.getUsername();
     }
 
+    public Long getUserId(){ return userAccessDto.getId();}
+
     @Override
     public boolean isAccountNonExpired() {
         return UserDetails.super.isAccountNonExpired();

--- a/src/main/java/blockchain/project/khu/apiserver/domain/user/dto/userDetails/UserAccessDto.java
+++ b/src/main/java/blockchain/project/khu/apiserver/domain/user/dto/userDetails/UserAccessDto.java
@@ -5,11 +5,13 @@ import lombok.Getter;
 
 @Getter
 public class UserAccessDto {
+    private Long id;
     private String username;
     private String role;
 
     @Builder
-    public UserAccessDto(String username, String role) {
+    public UserAccessDto(Long id, String username, String role) {
+        this.id = id;
         this.username = username;
         this.role = role;
     }

--- a/src/main/java/blockchain/project/khu/apiserver/domain/user/jwt/JWTFilter.java
+++ b/src/main/java/blockchain/project/khu/apiserver/domain/user/jwt/JWTFilter.java
@@ -36,7 +36,14 @@ public class JWTFilter extends OncePerRequestFilter {
             return;
         }
 
-        String access = request.getHeader("access");
+        String authHeader = request.getHeader("Authorization");
+
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            log.warn("Missing or invalid Authorization header");
+            throw new JWTException.TokenNullException();
+        }
+
+        String access = authHeader.substring(7); // "Bearer " 이후 토큰만 추출
 
         // validation1 - token null
         if (access == null) {
@@ -60,10 +67,12 @@ public class JWTFilter extends OncePerRequestFilter {
 
         String username = jwtUtil.getUsername(access);
         String role = jwtUtil.getRole(access);
+        Long id = jwtUtil.getId(access);
 
         UserAccessDto userAccessDto = UserAccessDto.builder()
                 .username(username)
                 .role(role)
+                .id(id)
                 .build();
 
         // USER
@@ -79,8 +88,5 @@ public class JWTFilter extends OncePerRequestFilter {
         else{
             filterChain.doFilter(request, response);
         }
-
-
-
     }
 }

--- a/src/main/java/blockchain/project/khu/apiserver/domain/user/jwt/JWTUtil.java
+++ b/src/main/java/blockchain/project/khu/apiserver/domain/user/jwt/JWTUtil.java
@@ -27,6 +27,9 @@ public class JWTUtil {
         return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("role", String.class);
     }
 
+    public Long getId(String token){
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("id", Long.class);
+    }
     public Boolean isExpired(String token) {
 
         return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().getExpiration().before(new Date());
@@ -36,12 +39,13 @@ public class JWTUtil {
         return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("category", String.class);
     }
 
-    public String createJwt(String category, String username, String role, Long expiredMs) {
+    public String createJwt(Long id, String category, String username, String role, Long expiredMs) {
 
         return Jwts.builder()
                 .claim("category", category)
                 .claim("username", username)
                 .claim("role", role)
+                .claim("id",id)
                 .issuedAt(new Date(System.currentTimeMillis()))
                 .expiration(new Date(System.currentTimeMillis() + expiredMs))
                 .signWith(secretKey)

--- a/src/main/java/blockchain/project/khu/apiserver/domain/user/service/UserCommandService.java
+++ b/src/main/java/blockchain/project/khu/apiserver/domain/user/service/UserCommandService.java
@@ -52,8 +52,8 @@ public class UserCommandService {
         log.info("[UserCommandService - issueToken]");
         User user = userRepository.findByUsername(username).orElseThrow(UserException.UsernameNotExistException::new);
 
-        String accessToken = jwtUtil.createJwt("access", user.getUsername(), user.getRole(), 10 * 60 * 1000L); // 10분
-        String refreshToken = jwtUtil.createJwt("refresh", user.getUsername(), user.getRole(), 24 * 60 * 60 * 1000L); // 1일
+        String accessToken = jwtUtil.createJwt(user.getId(),"access", user.getUsername(), user.getRole(), 10 * 60 * 1000L); // 10분
+        String refreshToken = jwtUtil.createJwt(user.getId(),"refresh", user.getUsername(), user.getRole(), 24 * 60 * 60 * 1000L); // 1일
 
         String redisRefreshKey = "refresh:userId:" + user.getId();
         stringRedisTemplate.opsForValue().set(redisRefreshKey, refreshToken, 1, TimeUnit.DAYS);
@@ -92,8 +92,8 @@ public class UserCommandService {
         stringRedisTemplate.delete(redisRefreshKey);
 
         // access, refresh 모두 재발급
-        String newAccessToken = jwtUtil.createJwt("access", user.getUsername(), jwtUtil.getRole(refreshToken), 10 * 60 * 1000L);
-        String newRefreshToken = jwtUtil.createJwt("refresh", user.getUsername(), jwtUtil.getRole(refreshToken), 24 * 60 * 60 * 1000L);
+        String newAccessToken = jwtUtil.createJwt(user.getId(),"access", user.getUsername(), jwtUtil.getRole(refreshToken), 10 * 60 * 1000L);
+        String newRefreshToken = jwtUtil.createJwt(user.getId(),"refresh", user.getUsername(), jwtUtil.getRole(refreshToken), 24 * 60 * 60 * 1000L);
 
         // new refresh 1 day 유지
         stringRedisTemplate.opsForValue().set(redisRefreshKey, newRefreshToken, 1, TimeUnit.DAYS);


### PR DESCRIPTION
## 개요
매물(Trade) 관련 등록, 조회, 수정, 삭제 기능을 위한 CRUD API를 구현하였습니다.

## 주요 작업 내용
- 매물 등록 API: `POST /api/property`
- 매물 상세 조회 API: `GET /api/property/{id}`
- 매물 목록 조회 API: `GET /api/property`
- 매물 수정 API: `PUT /api/property/{id}`
- 매물 삭제 API: `DELETE /api/prpperty/{id}`

## 기타 변경 사항
- Entity, DTO, Service, Controller 계층 설계
- 유효성 검증 및 예외 처리 적용

## 관련 이슈
Closes #1 
