### PR TITLE
임대 계약 생성 / 계약에 대한 월세 납부 API 구현

### DIFF
--- a/src/main/java/blockchain/project/khu/apiserver/common/annotation/CurrentUser.java
+++ b/src/main/java/blockchain/project/khu/apiserver/common/annotation/CurrentUser.java
@@ -1,0 +1,11 @@
+package blockchain.project.khu.apiserver.common.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CurrentUser {
+}

--- a/src/main/java/blockchain/project/khu/apiserver/common/annotation/resolver/AuthenticatedMemberResolver.java
+++ b/src/main/java/blockchain/project/khu/apiserver/common/annotation/resolver/AuthenticatedMemberResolver.java
@@ -1,0 +1,46 @@
+package blockchain.project.khu.apiserver.common.annotation.resolver;
+
+import blockchain.project.khu.apiserver.common.annotation.CurrentUser;
+import blockchain.project.khu.apiserver.domain.user.dto.userDetails.RoleUserDetails;
+import blockchain.project.khu.apiserver.domain.user.entity.User;
+import blockchain.project.khu.apiserver.domain.user.service.UserQueryService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class AuthenticatedMemberResolver implements HandlerMethodArgumentResolver {
+
+    private final UserQueryService userQueryService;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(CurrentUser.class)
+                && User.class.isAssignableFrom(parameter.getParameterType());
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return null;
+        }
+
+        Object principal = authentication.getPrincipal();
+        if (principal instanceof RoleUserDetails roleDetails) {
+            Long userId = roleDetails.getUserAccessDto().getId();
+            return userQueryService.getUserById(userId);
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/blockchain/project/khu/apiserver/common/apiPayload/failure/customException/RentException.java
+++ b/src/main/java/blockchain/project/khu/apiserver/common/apiPayload/failure/customException/RentException.java
@@ -1,0 +1,16 @@
+package blockchain.project.khu.apiserver.common.apiPayload.failure.customException;
+
+public class RentException {
+
+    public static class RentNotFoundException extends RuntimeException {
+        public RentNotFoundException() {
+            super("존재하지 않는 계약입니다.");
+        }
+    }
+
+    public static class InvalidRentStateException extends RuntimeException {
+        public InvalidRentStateException() {
+            super("계약 상태가 유효하지 않습니다.");
+        }
+    }
+}

--- a/src/main/java/blockchain/project/khu/apiserver/common/apiPayload/success/SuccessApiResponse.java
+++ b/src/main/java/blockchain/project/khu/apiserver/common/apiPayload/success/SuccessApiResponse.java
@@ -1,11 +1,10 @@
 package blockchain.project.khu.apiserver.common.apiPayload.success;
 
 import blockchain.project.khu.apiserver.common.apiPayload.BaseApiResponse;
-import blockchain.project.khu.apiserver.domain.funding.dto.request.FundingRequestDto;
 import blockchain.project.khu.apiserver.domain.funding.dto.response.FundingResponseDto;
 import blockchain.project.khu.apiserver.domain.property.dto.response.PropertyResponseDto;
+import blockchain.project.khu.apiserver.domain.rentPayment.dto.response.RentPaymentResponseDto;
 import blockchain.project.khu.apiserver.domain.user.dto.response.LoginResponse;
-import com.sun.net.httpserver.Authenticator;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
@@ -74,5 +73,9 @@ public class SuccessApiResponse <T> extends BaseApiResponse {
 
     public static SuccessApiResponse<Void> deleteFunding() {
         return new SuccessApiResponse<>(true, HttpStatus.OK.toString(), "펀딩 삭제 성공", null);
+    }
+
+    public static SuccessApiResponse<RentPaymentResponseDto> payRent(RentPaymentResponseDto responseDto) {
+        return new SuccessApiResponse<>(true, HttpStatus.OK.toString(), "월세 납부 성공", responseDto);
     }
 }

--- a/src/main/java/blockchain/project/khu/apiserver/common/apiPayload/success/SuccessApiResponse.java
+++ b/src/main/java/blockchain/project/khu/apiserver/common/apiPayload/success/SuccessApiResponse.java
@@ -90,6 +90,10 @@ public class SuccessApiResponse <T> extends BaseApiResponse {
         return new SuccessApiResponse<>(true, HttpStatus.OK.toString(), "등록한 매물별 월세 조회 성공", result);
     }
 
+    public static SuccessApiResponse<List<RentPaymentResponseDto>> getPaymentsByPropertyId(List<RentPaymentResponseDto> result) {
+        return new SuccessApiResponse<>(true, HttpStatus.OK.toString(), "특정 매물 월세 납부 내역 조회 성공", result);
+    }
+
     public static <T> SuccessApiResponse<T> success(T data, String message) {
         return new SuccessApiResponse<>(true, HttpStatus.OK.toString(), message, data);
     }

--- a/src/main/java/blockchain/project/khu/apiserver/common/apiPayload/success/SuccessApiResponse.java
+++ b/src/main/java/blockchain/project/khu/apiserver/common/apiPayload/success/SuccessApiResponse.java
@@ -78,4 +78,8 @@ public class SuccessApiResponse <T> extends BaseApiResponse {
     public static SuccessApiResponse<RentPaymentResponseDto> payRent(RentPaymentResponseDto responseDto) {
         return new SuccessApiResponse<>(true, HttpStatus.OK.toString(), "월세 납부 성공", responseDto);
     }
+
+    public static SuccessApiResponse<List<RentPaymentResponseDto>> getMyPayments(List<RentPaymentResponseDto> result) {
+        return new SuccessApiResponse<>(true, HttpStatus.OK.toString(), "월세 납부 내역 조회 성공", result);
+    }
 }

--- a/src/main/java/blockchain/project/khu/apiserver/common/apiPayload/success/SuccessApiResponse.java
+++ b/src/main/java/blockchain/project/khu/apiserver/common/apiPayload/success/SuccessApiResponse.java
@@ -2,6 +2,7 @@ package blockchain.project.khu.apiserver.common.apiPayload.success;
 
 import blockchain.project.khu.apiserver.common.apiPayload.BaseApiResponse;
 import blockchain.project.khu.apiserver.domain.funding.dto.response.FundingResponseDto;
+import blockchain.project.khu.apiserver.domain.property.dto.response.PropertyPaymentResponseDto;
 import blockchain.project.khu.apiserver.domain.property.dto.response.PropertyResponseDto;
 import blockchain.project.khu.apiserver.domain.rentPayment.dto.response.RentPaymentResponseDto;
 import blockchain.project.khu.apiserver.domain.user.dto.response.LoginResponse;
@@ -75,11 +76,21 @@ public class SuccessApiResponse <T> extends BaseApiResponse {
         return new SuccessApiResponse<>(true, HttpStatus.OK.toString(), "펀딩 삭제 성공", null);
     }
 
+
+    // [RENT-PAYMENT]
     public static SuccessApiResponse<RentPaymentResponseDto> payRent(RentPaymentResponseDto responseDto) {
         return new SuccessApiResponse<>(true, HttpStatus.OK.toString(), "월세 납부 성공", responseDto);
     }
 
     public static SuccessApiResponse<List<RentPaymentResponseDto>> getMyPayments(List<RentPaymentResponseDto> result) {
         return new SuccessApiResponse<>(true, HttpStatus.OK.toString(), "월세 납부 내역 조회 성공", result);
+    }
+
+    public static SuccessApiResponse<List<PropertyPaymentResponseDto>> getPaymentsByProperty(List<PropertyPaymentResponseDto> result) {
+        return new SuccessApiResponse<>(true, HttpStatus.OK.toString(), "등록한 매물별 월세 조회 성공", result);
+    }
+
+    public static <T> SuccessApiResponse<T> success(T data, String message) {
+        return new SuccessApiResponse<>(true, HttpStatus.OK.toString(), message, data);
     }
 }

--- a/src/main/java/blockchain/project/khu/apiserver/common/config/WebConfig.java
+++ b/src/main/java/blockchain/project/khu/apiserver/common/config/WebConfig.java
@@ -1,0 +1,21 @@
+package blockchain.project.khu.apiserver.common.config;
+
+import blockchain.project.khu.apiserver.common.annotation.resolver.AuthenticatedMemberResolver;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    private final AuthenticatedMemberResolver authenticatedMemberResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(authenticatedMemberResolver);
+    }
+}

--- a/src/main/java/blockchain/project/khu/apiserver/domain/property/dto/response/PropertyPaymentResponseDto.java
+++ b/src/main/java/blockchain/project/khu/apiserver/domain/property/dto/response/PropertyPaymentResponseDto.java
@@ -1,0 +1,43 @@
+package blockchain.project.khu.apiserver.domain.property.dto.response;
+
+import blockchain.project.khu.apiserver.domain.property.entity.Property;
+import blockchain.project.khu.apiserver.domain.rentPayment.dto.response.RentPaymentResponseDto;
+import blockchain.project.khu.apiserver.domain.rentPayment.entity.RentPayment;
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PropertyPaymentResponseDto {
+    private Long propertyId;
+    private String propertyName;
+    private BigDecimal totalReceived;
+    private int paymentCount;
+    private List<RentPaymentResponseDto> payments;
+
+    public static PropertyPaymentResponseDto fromEntity(
+            Property property,
+            List<RentPayment> paymentEntities
+    ) {
+        List<RentPaymentResponseDto> paymentDtos = paymentEntities.stream()
+                .map(RentPaymentResponseDto::fromEntity)
+                .toList();
+
+        BigDecimal total = paymentDtos.stream()
+                .map(RentPaymentResponseDto::getAmount)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+        return PropertyPaymentResponseDto.builder()
+                .propertyId(property.getId())
+                .propertyName(property.getName())
+                .totalReceived(total)
+                .paymentCount(paymentDtos.size())
+                .payments(paymentDtos)
+                .build();
+    }
+}

--- a/src/main/java/blockchain/project/khu/apiserver/domain/property/repository/PropertyRepository.java
+++ b/src/main/java/blockchain/project/khu/apiserver/domain/property/repository/PropertyRepository.java
@@ -4,6 +4,9 @@ import blockchain.project.khu.apiserver.domain.property.entity.Property;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface PropertyRepository extends JpaRepository<Property, Long> {
+    List<Property> findByUserId(Long userId);
 }

--- a/src/main/java/blockchain/project/khu/apiserver/domain/rent/controller/RentController.java
+++ b/src/main/java/blockchain/project/khu/apiserver/domain/rent/controller/RentController.java
@@ -1,0 +1,22 @@
+package blockchain.project.khu.apiserver.domain.rent.controller;
+
+import blockchain.project.khu.apiserver.domain.rent.dto.request.RentRequestDto;
+import blockchain.project.khu.apiserver.domain.rent.entity.Rent;
+import blockchain.project.khu.apiserver.domain.rent.service.RentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/rents")
+@RequiredArgsConstructor
+public class RentController {
+
+    private final RentService rentService;
+
+    @PostMapping
+    public ResponseEntity<Rent> createRent(@RequestBody RentRequestDto dto) {
+        Rent rent = rentService.createRent(dto);
+        return ResponseEntity.ok(rent);
+    }
+}

--- a/src/main/java/blockchain/project/khu/apiserver/domain/rent/dto/request/RentRequestDto.java
+++ b/src/main/java/blockchain/project/khu/apiserver/domain/rent/dto/request/RentRequestDto.java
@@ -1,0 +1,17 @@
+package blockchain.project.khu.apiserver.domain.rent.dto.request;
+
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Getter
+public class RentRequestDto {
+    private Long userId;
+    private Long propertyId;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private BigDecimal monthlyRent;
+    private BigDecimal deposit;
+    private Integer paymentDay;
+}

--- a/src/main/java/blockchain/project/khu/apiserver/domain/rent/entity/Rent.java
+++ b/src/main/java/blockchain/project/khu/apiserver/domain/rent/entity/Rent.java
@@ -1,0 +1,52 @@
+package blockchain.project.khu.apiserver.domain.rent.entity;
+
+import blockchain.project.khu.apiserver.domain.property.entity.Property;
+import blockchain.project.khu.apiserver.domain.rent.enumerate.RentStatus;
+import blockchain.project.khu.apiserver.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "rent")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Rent {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "rent_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "property_id", nullable = false)
+    private Property property;
+
+    @Column(name = "start_date", nullable = false)
+    private LocalDate startDate;
+
+    @Column(name = "end_date", nullable = false)
+    private LocalDate endDate;
+
+    @Column(name = "monthly_rent", nullable = false)
+    private BigDecimal monthlyRent;
+
+    @Column(name = "deposit", nullable = false)
+    private BigDecimal deposit;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private RentStatus status;  // e.g., ACTIVE, ENDED, CANCELLED
+
+    @Column(name = "payment_day", nullable = false)
+    private Integer paymentDay;  // 매달 납부일 (예: 5)
+}
+

--- a/src/main/java/blockchain/project/khu/apiserver/domain/rent/entity/Rent.java
+++ b/src/main/java/blockchain/project/khu/apiserver/domain/rent/entity/Rent.java
@@ -24,7 +24,7 @@ public class Rent {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
-    private User user;
+    private User tenant;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "property_id", nullable = false)

--- a/src/main/java/blockchain/project/khu/apiserver/domain/rent/entity/Rent.java
+++ b/src/main/java/blockchain/project/khu/apiserver/domain/rent/entity/Rent.java
@@ -24,7 +24,7 @@ public class Rent {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
-    private User tenant;
+    private User user;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "property_id", nullable = false)

--- a/src/main/java/blockchain/project/khu/apiserver/domain/rent/enumerate/RentStatus.java
+++ b/src/main/java/blockchain/project/khu/apiserver/domain/rent/enumerate/RentStatus.java
@@ -1,0 +1,15 @@
+package blockchain.project.khu.apiserver.domain.rent.enumerate;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum RentStatus {
+    ACTIVE("임대 중"),
+    ENDED("종료됨"),
+    CANCELLED("취소됨");
+
+    private final String key;
+}
+

--- a/src/main/java/blockchain/project/khu/apiserver/domain/rent/repository/RentRepository.java
+++ b/src/main/java/blockchain/project/khu/apiserver/domain/rent/repository/RentRepository.java
@@ -6,6 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface RentRepository extends JpaRepository<Rent, Long> {
-    List<Rent> findByTenantId(Long userId);
+    List<Rent> findByUserId(Long userId);
     List<Rent> findByPropertyId(Long propertyId);
 }

--- a/src/main/java/blockchain/project/khu/apiserver/domain/rent/repository/RentRepository.java
+++ b/src/main/java/blockchain/project/khu/apiserver/domain/rent/repository/RentRepository.java
@@ -1,0 +1,11 @@
+package blockchain.project.khu.apiserver.domain.rent.repository;
+
+import blockchain.project.khu.apiserver.domain.rent.entity.Rent;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface RentRepository extends JpaRepository<Rent, Long> {
+    List<Rent> findByTenantId(Long userId);
+    List<Rent> findByPropertyId(Long propertyId);
+}

--- a/src/main/java/blockchain/project/khu/apiserver/domain/rent/service/RentService.java
+++ b/src/main/java/blockchain/project/khu/apiserver/domain/rent/service/RentService.java
@@ -1,0 +1,41 @@
+package blockchain.project.khu.apiserver.domain.rent.service;
+
+import blockchain.project.khu.apiserver.domain.property.entity.Property;
+import blockchain.project.khu.apiserver.domain.property.repository.PropertyRepository;
+import blockchain.project.khu.apiserver.domain.rent.dto.request.RentRequestDto;
+import blockchain.project.khu.apiserver.domain.rent.entity.Rent;
+import blockchain.project.khu.apiserver.domain.rent.enumerate.RentStatus;
+import blockchain.project.khu.apiserver.domain.rent.repository.RentRepository;
+import blockchain.project.khu.apiserver.domain.user.entity.User;
+import blockchain.project.khu.apiserver.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RentService {
+
+    private final RentRepository rentRepository;
+    private final UserRepository userRepository;
+    private final PropertyRepository propertyRepository;
+
+    public Rent createRent(RentRequestDto dto) {
+        User user = userRepository.findById(dto.getUserId())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 유저입니다."));
+        Property property = propertyRepository.findById(dto.getPropertyId())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 매물입니다."));
+
+        Rent rent = Rent.builder()
+                .tenant(user)
+                .property(property)
+                .startDate(dto.getStartDate())
+                .endDate(dto.getEndDate())
+                .monthlyRent(dto.getMonthlyRent())
+                .deposit(dto.getDeposit())
+                .paymentDay(dto.getPaymentDay())
+                .status(RentStatus.ACTIVE)
+                .build();
+
+        return rentRepository.save(rent);
+    }
+}

--- a/src/main/java/blockchain/project/khu/apiserver/domain/rent/service/RentService.java
+++ b/src/main/java/blockchain/project/khu/apiserver/domain/rent/service/RentService.java
@@ -26,7 +26,7 @@ public class RentService {
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 매물입니다."));
 
         Rent rent = Rent.builder()
-                .tenant(user)
+                .user(user)
                 .property(property)
                 .startDate(dto.getStartDate())
                 .endDate(dto.getEndDate())

--- a/src/main/java/blockchain/project/khu/apiserver/domain/rentPayment/controller/RentPaymentController.java
+++ b/src/main/java/blockchain/project/khu/apiserver/domain/rentPayment/controller/RentPaymentController.java
@@ -41,4 +41,12 @@ public class RentPaymentController {
         List<PropertyPaymentResponseDto> result = rentPaymentService.getReceivedByProperty(user.getId());
         return SuccessApiResponse.getPaymentsByProperty(result);
     }
+
+    @GetMapping("/property/{propertyId}")
+    public SuccessApiResponse<List<RentPaymentResponseDto>> getPaymentsByPropertyId(
+            @PathVariable Long propertyId
+    ) {
+        List<RentPaymentResponseDto> result = rentPaymentService.getPaymentsByPropertyId(propertyId);
+        return SuccessApiResponse.getPaymentsByPropertyId(result);
+    }
 }

--- a/src/main/java/blockchain/project/khu/apiserver/domain/rentPayment/controller/RentPaymentController.java
+++ b/src/main/java/blockchain/project/khu/apiserver/domain/rentPayment/controller/RentPaymentController.java
@@ -1,15 +1,16 @@
 package blockchain.project.khu.apiserver.domain.rentPayment.controller;
 
+import blockchain.project.khu.apiserver.common.annotation.CurrentUser;
 import blockchain.project.khu.apiserver.common.apiPayload.success.SuccessApiResponse;
 import blockchain.project.khu.apiserver.domain.rentPayment.dto.request.RentPaymentRequestDto;
 import blockchain.project.khu.apiserver.domain.rentPayment.dto.response.RentPaymentResponseDto;
 import blockchain.project.khu.apiserver.domain.rentPayment.service.RentPaymentService;
+import blockchain.project.khu.apiserver.domain.user.entity.User;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/rent-payment")
@@ -22,5 +23,14 @@ public class RentPaymentController {
     public SuccessApiResponse<RentPaymentResponseDto> payRent(@Valid @RequestBody RentPaymentRequestDto requestDto) {
         RentPaymentResponseDto rentPaymentResponseDto = rentPaymentService.payRent(requestDto);
         return SuccessApiResponse.payRent(rentPaymentResponseDto);
+    }
+
+    @GetMapping("/my")
+    public SuccessApiResponse<List<RentPaymentResponseDto>> getMyPayments(
+            @CurrentUser User user
+    ) {
+        System.out.println(user.getUsername());
+        List<RentPaymentResponseDto> result = rentPaymentService.getMyPayments(user.getId());
+        return SuccessApiResponse.getMyPayments(result);
     }
 }

--- a/src/main/java/blockchain/project/khu/apiserver/domain/rentPayment/controller/RentPaymentController.java
+++ b/src/main/java/blockchain/project/khu/apiserver/domain/rentPayment/controller/RentPaymentController.java
@@ -2,6 +2,7 @@ package blockchain.project.khu.apiserver.domain.rentPayment.controller;
 
 import blockchain.project.khu.apiserver.common.annotation.CurrentUser;
 import blockchain.project.khu.apiserver.common.apiPayload.success.SuccessApiResponse;
+import blockchain.project.khu.apiserver.domain.property.dto.response.PropertyPaymentResponseDto;
 import blockchain.project.khu.apiserver.domain.rentPayment.dto.request.RentPaymentRequestDto;
 import blockchain.project.khu.apiserver.domain.rentPayment.dto.response.RentPaymentResponseDto;
 import blockchain.project.khu.apiserver.domain.rentPayment.service.RentPaymentService;
@@ -29,8 +30,15 @@ public class RentPaymentController {
     public SuccessApiResponse<List<RentPaymentResponseDto>> getMyPayments(
             @CurrentUser User user
     ) {
-        System.out.println(user.getUsername());
         List<RentPaymentResponseDto> result = rentPaymentService.getMyPayments(user.getId());
         return SuccessApiResponse.getMyPayments(result);
+    }
+
+    @GetMapping("/by-property")
+    public SuccessApiResponse<List<PropertyPaymentResponseDto>> getPaymentsByProperty(
+            @CurrentUser User user
+    ) {
+        List<PropertyPaymentResponseDto> result = rentPaymentService.getReceivedByProperty(user.getId());
+        return SuccessApiResponse.getPaymentsByProperty(result);
     }
 }

--- a/src/main/java/blockchain/project/khu/apiserver/domain/rentPayment/controller/RentPaymentController.java
+++ b/src/main/java/blockchain/project/khu/apiserver/domain/rentPayment/controller/RentPaymentController.java
@@ -1,0 +1,26 @@
+package blockchain.project.khu.apiserver.domain.rentPayment.controller;
+
+import blockchain.project.khu.apiserver.common.apiPayload.success.SuccessApiResponse;
+import blockchain.project.khu.apiserver.domain.rentPayment.dto.request.RentPaymentRequestDto;
+import blockchain.project.khu.apiserver.domain.rentPayment.dto.response.RentPaymentResponseDto;
+import blockchain.project.khu.apiserver.domain.rentPayment.service.RentPaymentService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/rent-payment")
+@RequiredArgsConstructor
+public class RentPaymentController {
+
+    private final RentPaymentService rentPaymentService;
+
+    @PostMapping
+    public SuccessApiResponse<RentPaymentResponseDto> payRent(@Valid @RequestBody RentPaymentRequestDto requestDto) {
+        RentPaymentResponseDto rentPaymentResponseDto = rentPaymentService.payRent(requestDto);
+        return SuccessApiResponse.payRent(rentPaymentResponseDto);
+    }
+}

--- a/src/main/java/blockchain/project/khu/apiserver/domain/rentPayment/dto/request/RentPaymentRequestDto.java
+++ b/src/main/java/blockchain/project/khu/apiserver/domain/rentPayment/dto/request/RentPaymentRequestDto.java
@@ -1,0 +1,33 @@
+package blockchain.project.khu.apiserver.domain.rentPayment.dto.request;
+
+import blockchain.project.khu.apiserver.domain.rent.entity.Rent;
+import blockchain.project.khu.apiserver.domain.rentPayment.entity.RentPayment;
+import blockchain.project.khu.apiserver.domain.rentPayment.enumerate.PaymentStatus;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Getter
+@Builder
+public class RentPaymentRequestDto {
+
+    @NotNull(message = "rentId는 필수입니다.")
+    private Long rentId;
+
+    @NotNull(message = "amount는 필수입니다.")
+    @DecimalMin(value = "0.0", inclusive = false, message = "금액은 0보다 커야 합니다.")
+    private BigDecimal amount;
+
+    public RentPayment toEntity(Rent rent) {
+        return RentPayment.builder()
+                .rent(rent)
+                .amount(amount)
+                .paidAt(LocalDate.now())
+                .status(PaymentStatus.PAID)
+                .build();
+    }
+}

--- a/src/main/java/blockchain/project/khu/apiserver/domain/rentPayment/dto/response/RentPaymentResponseDto.java
+++ b/src/main/java/blockchain/project/khu/apiserver/domain/rentPayment/dto/response/RentPaymentResponseDto.java
@@ -1,0 +1,38 @@
+package blockchain.project.khu.apiserver.domain.rentPayment.dto.response;
+
+import blockchain.project.khu.apiserver.domain.rentPayment.entity.RentPayment;
+import blockchain.project.khu.apiserver.domain.rentPayment.enumerate.PaymentStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RentPaymentResponseDto {
+
+    private Long paymentId;
+    private Long rentId;
+    private Long tenantId;
+    private Long propertyId;
+    private BigDecimal amount;
+    private LocalDate paidAt;
+    private PaymentStatus status;
+
+    public static RentPaymentResponseDto fromEntity(RentPayment payment) {
+        return RentPaymentResponseDto.builder()
+                .paymentId(payment.getId())
+                .rentId(payment.getRent().getId())
+                .tenantId(payment.getRent().getUser().getId())
+                .propertyId(payment.getRent().getProperty().getId())
+                .amount(payment.getAmount())
+                .paidAt(payment.getPaidAt())
+                .status(payment.getStatus())
+                .build();
+    }
+}

--- a/src/main/java/blockchain/project/khu/apiserver/domain/rentPayment/entity/RentPayment.java
+++ b/src/main/java/blockchain/project/khu/apiserver/domain/rentPayment/entity/RentPayment.java
@@ -1,0 +1,37 @@
+package blockchain.project.khu.apiserver.domain.rentPayment.entity;
+
+import blockchain.project.khu.apiserver.domain.rent.entity.Rent;
+import blockchain.project.khu.apiserver.domain.rentPayment.enumerate.PaymentStatus;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "rent_payment")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class RentPayment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "payment_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "rent_id", nullable = false)
+    private Rent rent;
+
+    @Column(name = "paid_at", nullable = false)
+    private LocalDate paidAt;
+
+    @Column(nullable = false)
+    private BigDecimal amount;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private PaymentStatus status;
+}

--- a/src/main/java/blockchain/project/khu/apiserver/domain/rentPayment/enumerate/PaymentStatus.java
+++ b/src/main/java/blockchain/project/khu/apiserver/domain/rentPayment/enumerate/PaymentStatus.java
@@ -1,0 +1,14 @@
+package blockchain.project.khu.apiserver.domain.rentPayment.enumerate;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum PaymentStatus {
+    PAID("납부 완료"),
+    LATE("연체"),
+    UNPAID("미납");
+
+    private final String key;
+}

--- a/src/main/java/blockchain/project/khu/apiserver/domain/rentPayment/repository/RentPaymentCustomRepository.java
+++ b/src/main/java/blockchain/project/khu/apiserver/domain/rentPayment/repository/RentPaymentCustomRepository.java
@@ -1,0 +1,4 @@
+package blockchain.project.khu.apiserver.domain.rentPayment.repository;
+
+public interface RentPaymentCustomRepository {
+}

--- a/src/main/java/blockchain/project/khu/apiserver/domain/rentPayment/repository/RentPaymentCustomRepositoryImpl.java
+++ b/src/main/java/blockchain/project/khu/apiserver/domain/rentPayment/repository/RentPaymentCustomRepositoryImpl.java
@@ -1,0 +1,4 @@
+package blockchain.project.khu.apiserver.domain.rentPayment.repository;
+
+public class RentPaymentCustomRepositoryImpl implements RentPaymentCustomRepository{
+}

--- a/src/main/java/blockchain/project/khu/apiserver/domain/rentPayment/repository/RentPaymentRepository.java
+++ b/src/main/java/blockchain/project/khu/apiserver/domain/rentPayment/repository/RentPaymentRepository.java
@@ -1,0 +1,7 @@
+package blockchain.project.khu.apiserver.domain.rentPayment.repository;
+
+import blockchain.project.khu.apiserver.domain.rentPayment.entity.RentPayment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RentPaymentRepository extends JpaRepository<RentPayment, Long> {
+}

--- a/src/main/java/blockchain/project/khu/apiserver/domain/rentPayment/repository/RentPaymentRepository.java
+++ b/src/main/java/blockchain/project/khu/apiserver/domain/rentPayment/repository/RentPaymentRepository.java
@@ -3,5 +3,8 @@ package blockchain.project.khu.apiserver.domain.rentPayment.repository;
 import blockchain.project.khu.apiserver.domain.rentPayment.entity.RentPayment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface RentPaymentRepository extends JpaRepository<RentPayment, Long> {
+    List<RentPayment> findByRentId(Long id);
 }

--- a/src/main/java/blockchain/project/khu/apiserver/domain/rentPayment/service/RentPaymentService.java
+++ b/src/main/java/blockchain/project/khu/apiserver/domain/rentPayment/service/RentPaymentService.java
@@ -1,0 +1,32 @@
+package blockchain.project.khu.apiserver.domain.rentPayment.service;
+
+import blockchain.project.khu.apiserver.common.apiPayload.failure.customException.RentException;
+import blockchain.project.khu.apiserver.domain.rent.entity.Rent;
+import blockchain.project.khu.apiserver.domain.rent.repository.RentRepository;
+import blockchain.project.khu.apiserver.domain.rentPayment.dto.request.RentPaymentRequestDto;
+import blockchain.project.khu.apiserver.domain.rentPayment.dto.response.RentPaymentResponseDto;
+import blockchain.project.khu.apiserver.domain.rentPayment.entity.RentPayment;
+import blockchain.project.khu.apiserver.domain.rentPayment.repository.RentPaymentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class RentPaymentService {
+
+    private final RentRepository rentRepository;
+    private final RentPaymentRepository rentPaymentRepository;
+
+    @Transactional
+    public RentPaymentResponseDto payRent(RentPaymentRequestDto requestDto) {
+        Rent rent = rentRepository.findById(requestDto.getRentId())
+                .orElseThrow(RentException.RentNotFoundException::new);
+
+        RentPayment payment = requestDto.toEntity(rent);
+        RentPayment saved = rentPaymentRepository.save(payment);
+
+        return RentPaymentResponseDto.fromEntity(saved);
+    }
+}

--- a/src/main/java/blockchain/project/khu/apiserver/domain/rentPayment/service/RentPaymentService.java
+++ b/src/main/java/blockchain/project/khu/apiserver/domain/rentPayment/service/RentPaymentService.java
@@ -11,6 +11,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
@@ -28,5 +30,14 @@ public class RentPaymentService {
         RentPayment saved = rentPaymentRepository.save(payment);
 
         return RentPaymentResponseDto.fromEntity(saved);
+    }
+
+    public List<RentPaymentResponseDto> getMyPayments(Long userId) {
+        List<Rent> rents = rentRepository.findByUserId(userId);
+
+        return rents.stream()
+                .flatMap(rent -> rentPaymentRepository.findByRentId(rent.getId()).stream())
+                .map(RentPaymentResponseDto::fromEntity)
+                .toList();
     }
 }

--- a/src/main/java/blockchain/project/khu/apiserver/domain/rentPayment/service/RentPaymentService.java
+++ b/src/main/java/blockchain/project/khu/apiserver/domain/rentPayment/service/RentPaymentService.java
@@ -62,4 +62,13 @@ public class RentPaymentService {
                 })
                 .toList();
     }
+
+    public List<RentPaymentResponseDto> getPaymentsByPropertyId(Long propertyId) {
+        List<Rent> rents = rentRepository.findByPropertyId(propertyId);
+
+        return rents.stream()
+                .flatMap(rent -> rentPaymentRepository.findByRentId(rent.getId()).stream())
+                .map(RentPaymentResponseDto::fromEntity)
+                .toList();
+    }
 }

--- a/src/main/java/blockchain/project/khu/apiserver/domain/user/service/UserQueryService.java
+++ b/src/main/java/blockchain/project/khu/apiserver/domain/user/service/UserQueryService.java
@@ -3,8 +3,8 @@ package blockchain.project.khu.apiserver.domain.user.service;
 import blockchain.project.khu.apiserver.common.apiPayload.failure.customException.UserException;
 import blockchain.project.khu.apiserver.domain.user.dto.request.LoginRequest;
 import blockchain.project.khu.apiserver.domain.user.entity.User;
-import blockchain.project.khu.apiserver.domain.user.jwt.JWTUtil;
 import blockchain.project.khu.apiserver.domain.user.repository.UserRepository;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -31,5 +31,10 @@ public class UserQueryService {
         }
 
         return user.getUsername();
+    }
+
+    public User getUserById(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 사용자 ID: " + userId));
     }
 }


### PR DESCRIPTION
## 💡 관련 이슈

- #5 

## 📝 작업 내용

- 월세 납부하기
- 로그인한 사용자의 월세 납부 내역 조회
- 로그인한 사용자의 매물 별 월세 납부 내역 조회
- 특정 매물의 월세 납부 내역 조회
- 로그인한 사용자 받기 위한 커스텀 어노테이션 @CurrentUser 생성
- 월세 납부를 위해 필요한 임대 계약 엔티티 생성 및 임대 계약 생성 API 구현

## 🧑‍💻 변경 사항
> 변경된 사항을 알려주세요


## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?